### PR TITLE
IntegrationDriver actions must return 'this' and only 'this'.

### DIFF
--- a/lib/rules/integration-drivers-return-this.js
+++ b/lib/rules/integration-drivers-return-this.js
@@ -1,0 +1,28 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'ensures IntegrationDriver action always return `this`',
+    },
+    schema: [],
+  },
+  create(context) {
+    let info = {};
+
+    return {
+      'ClassDeclaration[superClass.name=IntegrationDriver] MethodDefinition[key.name!=isLoaded][key.name!=constructor]': (node) => {
+        info.hasReturn = false;
+      },
+      'ClassDeclaration[superClass.name=IntegrationDriver] MethodDefinition[key.name!=isLoaded][key.name!=constructor] BlockStatement.body > ReturnStatement[argument.type!=ThisExpression]': (node) => {
+        context.report(node, "IntegrationDriver actions may not return anything but 'this'.");
+      },
+      'ClassDeclaration[superClass.name=IntegrationDriver] MethodDefinition[key.name!=isLoaded][key.name!=constructor] BlockStatement.body > ReturnStatement': (node) => {
+        info.hasReturn = true;
+      },
+      'ClassDeclaration[superClass.name=IntegrationDriver] MethodDefinition[key.name!=isLoaded][key.name!=constructor]:exit': (node) => {
+        if (!info.hasReturn) {
+          context.report(node, "IntegrationDriver actions must return 'this'.");
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
This rule ensures that IntegrationDriver actions always return `this`.

(Excludes the `constructor` and `isLoaded`.)

---

[Trello](https://trello.com/c/jjdvbrf8)