### PR TITLE
Restricts arbitrary code inside the integration.begin block.

### DIFF
--- a/lib/rules/integration-test-format.js
+++ b/lib/rules/integration-test-format.js
@@ -1,0 +1,25 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Inside the integration.begin block, all arbitrary code must be put in Driver actions.',
+      category: 'Stylistic Issues',
+      recommended: false,
+    },
+    fixable: false,
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      'CallExpression[callee.object.name=integration][callee.property.name=begin] VariableDeclaration': (node) => {
+        context.report(node, "Put arbitrary code inside a Driver action.");
+      },
+      'CallExpression[callee.object.name=integration][callee.property.name=begin] AssignmentExpression': (node) => {
+        context.report(node, "Put arbitrary code inside a Driver action.");
+      },
+      'CallExpression[callee.object.name=integration][callee.property.name=begin] CallExpression[callee.name=expect]': (node) => {
+        context.report(node, "Put expectations inside a Driver action that starts with 'read'.");
+      },
+    };
+  },
+};


### PR DESCRIPTION
It would be difficult to test for every possible way that someone could break the Integration test pattern, but this rule checks for a few of the most common ways:

* Declaring a new variable.
* Assigning a value to an existing variable.
* Calling `expect`.

---

[Trello](https://trello.com/c/IEsChA6d) | Required for Root-App/root-react-native#2204.