### PR TITLE
Excludes private functions from integration-drivers-return-this.

### DIFF
--- a/lib/rules/integration-drivers-return-this.js
+++ b/lib/rules/integration-drivers-return-this.js
@@ -11,16 +11,19 @@ module.exports = {
     return {
       'ClassDeclaration[superClass.name=IntegrationDriver] MethodDefinition[key.name!=isLoaded][key.name!=constructor]': (node) => {
         info.hasReturn = false;
+        info.isPrivate = (node.key.name[0] == "_");
       },
       'ClassDeclaration[superClass.name=IntegrationDriver] MethodDefinition[key.name!=isLoaded][key.name!=constructor] BlockStatement.body > ReturnStatement[argument.type!=ThisExpression]': (node) => {
-        context.report(node, "IntegrationDriver actions may not return anything but 'this'.");
+        if (!info.isPrivate) {
+          context.report(node, "Public IntegrationDriver actions may not return anything but 'this'.");
+        }
       },
       'ClassDeclaration[superClass.name=IntegrationDriver] MethodDefinition[key.name!=isLoaded][key.name!=constructor] BlockStatement.body > ReturnStatement': (node) => {
         info.hasReturn = true;
       },
       'ClassDeclaration[superClass.name=IntegrationDriver] MethodDefinition[key.name!=isLoaded][key.name!=constructor]:exit': (node) => {
-        if (!info.hasReturn) {
-          context.report(node, "IntegrationDriver actions must return 'this'.");
+        if (!info.hasReturn && !info.isPrivate) {
+          context.report(node, "Public IntegrationDriver actions must return 'this'.");
         }
       },
     };


### PR DESCRIPTION
It doesn't make sense to enforce this constraint for private functions, only public ones.

This PR excludes private functions from the rule.

---

[Trello](https://trello.com/c/jjdvbrf8) | Required for Root-App/root-react-native#2192.