### PR TITLE
Allow terminal actions to return null instead of this.

### DIFF
--- a/lib/rules/integration-drivers-return-this-or-null.js
+++ b/lib/rules/integration-drivers-return-this-or-null.js
@@ -1,7 +1,7 @@
 module.exports = {
   meta: {
     docs: {
-      description: 'ensures IntegrationDriver action always return `this`',
+      description: 'ensures IntegrationDriver actions always return `this` or `null`',
     },
     schema: [],
   },
@@ -13,9 +13,9 @@ module.exports = {
         info.hasReturn = false;
         info.isPrivate = (node.key.name[0] == "_");
       },
-      'ClassDeclaration[superClass.name=IntegrationDriver] MethodDefinition[key.name!=isLoaded][key.name!=constructor] BlockStatement.body > ReturnStatement[argument.type!=ThisExpression]': (node) => {
+      'ClassDeclaration[superClass.name=IntegrationDriver] MethodDefinition[key.name!=isLoaded][key.name!=constructor] BlockStatement.body > ReturnStatement[argument.type!=ThisExpression][argument.raw!=null]': (node) => {
         if (!info.isPrivate) {
-          context.report(node, "Public IntegrationDriver actions may not return anything but 'this'.");
+          context.report(node, "Do not return anything except 'this' (chainable) or 'null' (terminal).");
         }
       },
       'ClassDeclaration[superClass.name=IntegrationDriver] MethodDefinition[key.name!=isLoaded][key.name!=constructor] BlockStatement.body > ReturnStatement': (node) => {
@@ -23,7 +23,7 @@ module.exports = {
       },
       'ClassDeclaration[superClass.name=IntegrationDriver] MethodDefinition[key.name!=isLoaded][key.name!=constructor]:exit': (node) => {
         if (!info.hasReturn && !info.isPrivate) {
-          context.report(node, "Public IntegrationDriver actions must return 'this'.");
+          context.report(node, "Chainable actions must return 'this'. Terminal actions must return 'null'.");
         }
       },
     };


### PR DESCRIPTION
This allows `null` to be one of the accepted return types for an `IntegrationDriver` action.

The following distinction is made:

* Use `this` for driver actions that can be chained together.

* Use `null` for driver actions that navigate away from the current page. (No further actions are possible.)

---

[Trello](https://trello.com/c/CDwtbtAR)