### PR TITLE
Adds the integration-driver-import rule.

### DIFF
--- a/lib/rules/integration-driver-import.js
+++ b/lib/rules/integration-driver-import.js
@@ -1,0 +1,29 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Only import IntegrationDriver in integration tests',
+      category: 'Stylistic Issues',
+      recommended: false,
+    },
+    fixable: false,
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      'ImportDeclaration': (node) => {
+        const filename = context.getFilename();
+
+        const isIntegrationTest = filename.includes("test/integration");
+        const isIntegrationDriver = filename.includes("test/support/drivers/integration");
+        const isIntegrationHelper = filename.includes("test/support/integration-helper");
+
+        const isIntegrationDriverImport = node.source.value.startsWith('test/support/drivers/integration');
+
+        if (isIntegrationDriverImport && !(isIntegrationTest || isIntegrationDriver || isIntegrationHelper)) {
+          context.report(node, "Do not use IntegrationDriver outside of integration tests.");
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
This rule makes it so that `IntegrationDriver` can only be imported in three places:

* other integration drivers (usually for importing base classes)
* integration tests
* integration test helpers

In particular, it prevents them from being imported in normal unit tests.

---

[Trello](https://trello.com/c/e6FfLcLj)

