### PR TITLE
Add rule for preferring RootText over Text

### DIFF
--- a/lib/rules/prefer-root-text.js
+++ b/lib/rules/prefer-root-text.js
@@ -1,0 +1,38 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'ensures <RootText> is used instead of <Text>.',
+    },
+    fixable: 'code',
+    schema: [],
+  },
+  create(context) {
+    var sourceCode = context.getSourceCode();
+    return {
+      "JSXOpeningElement": (node) => {
+        if (node.name.name === 'Text') {
+          context.report({
+            node,
+            message: node.name.name + 'use RootText instead of Text',
+            fix: (fixer) => {
+              return fixer.replaceText(node, sourceCode.getText(node).replace('<Text', '<RootText'));
+            },
+          });
+        }
+        return;
+      },
+      "JSXClosingElement": (node) => {
+        if (node.name.name === 'Text') {
+          context.report({
+            node,
+            message: node.name.name + 'use RootText instead of Text',
+            fix: (fixer) => {
+              return fixer.replaceText(node, sourceCode.getText(node).replace('/Text>', '/RootText>'));
+            },
+          });
+        }
+        return;
+      },
+    }
+  },
+};


### PR DESCRIPTION
[Related React Native PR](https://github.com/Root-App/root-react-native/pull/2321/files)

When using RN `<Text>` element, its possible to forget to set a font or color, resulting in inconsistencies across platforms. We have added a new wrapper for `<Text>`, and this will enforce its use. 