### PR TITLE
Ensure wait/waitForElement are preceded by await

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # root-eslint-plugin
 Custom rules for Root Insurance
+
+## Helpful Resources
+
+* [AST Explorer](https://astexplorer.net/) - This tool will generate an AST for a given code snippet. Very useful for writing custom eslint rules.

--- a/lib/rules/preceded-by-await.js
+++ b/lib/rules/preceded-by-await.js
@@ -1,0 +1,37 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'ensures desired async functions are preceded by `await`.',
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          functionNames: {
+            default: [],
+            type: 'array',
+          },
+        },
+      },
+    ],
+  },
+  create(context) {
+    const configuration = context.options[0] || {};
+    const affectedFunctionNames = configuration.functionNames || [];
+
+    return {
+      CallExpression(node) {
+        const functionName = node.callee.name;
+        if (!affectedFunctionNames.includes(functionName)) { return; }
+        if (node.parent.type === 'AwaitExpression') { return; }
+
+        context.report({
+          node,
+          message: `${functionName} must be prefixed w/ 'await'`,
+          fix: (fixer) => fixer.insertTextBefore(node, 'await '),
+        });
+      }
+    };
+  }
+};

--- a/test/lib/rules/preceded-by-await-test.js
+++ b/test/lib/rules/preceded-by-await-test.js
@@ -1,0 +1,37 @@
+const rule = require('../../../lib/rules/preceded-by-await');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018 } });
+
+ruleTester.run('preceded-by-await', rule, {
+  valid: [
+    {
+      code: `describe("some test", async () => {
+               await wait(() => {});
+             });`,
+      options: [{ functionNames: ['wait'] }],
+    },
+    {
+      code: `describe("some test", async () => {
+               await waitForElement(() => {});
+             });`,
+      options: [{ functionNames: ['wait', 'waitForElement'] }],
+    },
+  ],
+  invalid: [
+    {
+      code: `describe("some test", async () => {
+               wait(() => {});
+             });`,
+      errors: [{ message: "wait must be prefixed w/ 'await'" }],
+      options: [{ functionNames: ['wait'] }],
+    },
+    {
+      code: `describe("some test", async () => {
+               waitForElement(() => {});
+             });`,
+      errors: [{ message: "waitForElement must be prefixed w/ 'await'" }],
+      options: [{ functionNames: ['wait', 'waitForElement'] }],
+    },
+  ],
+});


### PR DESCRIPTION
This will help prevent false positives in tests that forget to await the return of an async poll.

<img width="474" alt="screen shot 2018-08-27 at 11 53 19 am" src="https://user-images.githubusercontent.com/62091/44670126-d7f16700-a9ef-11e8-9cbe-00b76a370a9e.png">
