### PR TITLE
prevent use of relative file paths

### DIFF
--- a/lib/rules/prevent-relative-paths.js
+++ b/lib/rules/prevent-relative-paths.js
@@ -1,0 +1,18 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Do not use relative file paths',
+    },
+    fixable: false,
+  },
+
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if(node.source.value.includes('../') || node.source.value.includes('./')) {
+          context.report(node, 'Use absolute paths for file imports');
+        }
+      },
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root-eslint-plugin",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Custom rules for Root Insurance",
   "keywords": [
     "eslint",

--- a/test/lib/rules/prevent-relative-paths-test.js
+++ b/test/lib/rules/prevent-relative-paths-test.js
@@ -1,0 +1,46 @@
+const rule = require('../../../lib/rules/prevent-relative-paths');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester();
+const parserOptions = { sourceType: 'module' }
+const error = {
+	message: 'Use absolute paths for file imports',
+	type: 'ImportDeclaration',
+}
+
+ruleTester.run('prevent-relative-paths', rule, {
+  valid: [
+    {
+      code: `
+        import Something from 'modules/someFile';
+      `,
+      filename: 'components/some-component.js',
+      parserOptions: parserOptions,
+    },
+    {
+      code: `
+        import { something } from 'modules/someFile';
+      `,
+      filename: 'components/some-component.js',
+      parserOptions: parserOptions,
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        import Something from '../someFile';
+      `,
+      filename: 'components/some-component.js',
+      parserOptions: parserOptions,
+      errors: [error]
+    },
+    {
+      code: `
+        import Something from './someFile';
+      `,
+      filename: 'components/some-component.js',
+      parserOptions: parserOptions,
+      errors: [error]
+    },
+  ],
+});


### PR DESCRIPTION
Adds a linter rule that prevents the use of relative paths in import statements. The linter rule detects occurrences of `'../'` and `'./'`