### PR TITLE
Adds rule to prevent unused connect functions

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -81,6 +81,7 @@ module.exports = {
     'root/integration-test-format': 'error',
     'root/prefer-root-text': 'error',
     'root/preceded-by-await': ['error', { 'functionNames': ['pollForCondition', 'wait', 'waitForElement'] }],
+    'root/prevent-unused-connect-functions': 'error',
     'root/sort-reducers-index': 'error',
     'semi-spacing': 'error',
     'semi': 'error',

--- a/lib/rules/prevent-unused-connect-functions.js
+++ b/lib/rules/prevent-unused-connect-functions.js
@@ -1,0 +1,31 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Components should only be wrapped in a connect function when state or dispatch is being used',
+    },
+    fixable: false,
+  },
+
+  create(context) {
+    function nullLiteral(node) {
+        return node.type === 'Literal' && node.value === null;
+    }
+
+    function arrowFunctionWithUnusedParams(node) {
+        return node.type === 'ArrowFunctionExpression' && node.params.length === 0;
+    }
+
+    return {
+      'ExportDefaultDeclaration CallExpression[callee.name=connect][arguments]'(node) {
+        if (node && node.arguments && node.arguments.length > 2) {
+            const stateArgument = node.arguments[0];
+            const dispatchArgument = node.arguments[1];
+            
+            if ((nullLiteral(stateArgument) || arrowFunctionWithUnusedParams(stateArgument)) && (nullLiteral(dispatchArgument) || arrowFunctionWithUnusedParams(dispatchArgument))) {
+                context.report(node, 'Unwrap components from connect when connect is not used');
+            }
+        }
+      },
+    };
+  },
+};

--- a/test/lib/rules/prevent-unused-connect-functions-test.js
+++ b/test/lib/rules/prevent-unused-connect-functions-test.js
@@ -1,0 +1,58 @@
+const rule = require('../../../lib/rules/prevent-unused-connect-functions');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018, sourceType: 'module' } });
+
+ruleTester.run('prevent-unused-connect-functions', rule, {
+  valid: [
+    {
+      code: `export default connect(
+              (state) => ({}),
+              (dispatch) => ({}),
+              null,
+              {
+                withRef: true,
+              }
+            )`,
+      filename: 'components/some-component.js',
+    }
+  ],
+  invalid: [
+    {
+      code: `export default connect(
+              () => ({}),
+              () => ({}),
+              null,
+              {
+                withRef: true,
+              }
+            )`,
+      filename: 'components/some-component.js',
+      errors: [{ message: 'Unwrap components from connect when connect is not used' }]
+    },
+    {
+      code: `export default connect(
+              null,
+              () => ({}),
+              null,
+              {
+                withRef: true,
+              }
+            )`,
+      filename: 'components/some-component.js',
+      errors: [{ message: 'Unwrap components from connect when connect is not used' }]
+    },
+    {
+      code: `export default connect(
+              () => ({}),
+              null,
+              null,
+              {
+                withRef: true,
+              }
+            )`,
+      filename: 'components/some-component.js',
+      errors: [{ message: 'Unwrap components from connect when connect is not used' }]
+    },
+  ],
+});


### PR DESCRIPTION
We previously preferred wrapping every component in a connect function for convenience. In an effort to discourage the use of redux when unnecessary, this PR adds a linter rule to prevent unused connect functions.

This PR in `root-mobile` removes existing unused connect functions:
https://github.com/Root-App/root-mobile/pull/3822

<!-- probot = {"487052":{"current_lock":false,"slack_message_context_CEBE11H25":"1551468260.022000","slack_message_context_CF5U74N9K":"1551468265.008900","slack_message_context_C6BU2MHPC":"1551468267.050800"}} -->