### PR TITLE
Dont allow 404 to be an expected response code of network requests

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -76,6 +76,7 @@ module.exports = {
     'react/self-closing-comp': 'error',
     'react/sort-prop-types': ['error', { 'ignoreCase': true }],
     'rest-spread-spacing': 'error',
+    'root/dont-allow-404-response': 'error',
     'root/integration-drivers-return-this-or-null': 'error',
     'root/integration-driver-import': 'error',
     'root/integration-test-format': 'error',

--- a/lib/rules/dont-allow-404-response.js
+++ b/lib/rules/dont-allow-404-response.js
@@ -1,0 +1,42 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'do not allow 404 as expected response for network requests',
+    },
+    fixable: false,
+  },
+  create(context) {
+    return {
+      'AwaitExpression CallExpression ObjectExpression Property[key.name="expectedResponse"] > Literal[value=404]': (node) => {
+        context.report(node, "Use 204 instead of 404 status code to indicate no content");
+      },
+      'AwaitExpression CallExpression ObjectExpression Property[key.name="expectedResponse"] > ArrayExpression > Literal[value=404]': (node) => {
+        context.report(node, "Use 204 instead of 404 status code to indicate no content");
+      },
+      'AwaitExpression CallExpression ObjectExpression Property[key.name="expectedErrorResponses"] > Literal[value=404]': (node) => {
+        context.report(node, "Use 204 instead of 404 status code to indicate no content");
+      },
+      'AwaitExpression CallExpression ObjectExpression Property[key.name="expectedErrorResponses"] > ArrayExpression > Literal[value=404]': (node) => {
+        context.report(node, "Use 204 instead of 404 status code to indicate no content");
+      },
+      'AwaitExpression CallExpression ObjectExpression Property[key.name="expectedErrors"] > Literal[value=404]': (node) => {
+        context.report(node, "Use 204 instead of 404 status code to indicate no content");
+      },
+      'AwaitExpression CallExpression ObjectExpression Property[key.name="expectedErrors"] > ArrayExpression > Literal[value=404]': (node) => {
+        context.report(node, "Use 204 instead of 404 status code to indicate no content");
+      },
+      'NewExpression[callee.name="NetworkRequestConfiguration"] ObjectExpression Property[key.name="successCodes"] > Literal[value=404]': (node) => {
+        context.report(node, "Use 204 instead of 404 status code to indicate no content");
+      },
+      'NewExpression[callee.name="NetworkRequestConfiguration"] ObjectExpression Property[key.name="errorCodes"] > Literal[value=404]': (node) => {
+        context.report(node, "Use 204 instead of 404 status code to indicate no content");
+      },
+      'NewExpression[callee.name="NetworkRequestConfiguration"] ObjectExpression Property[key.name="successCodes"] ArrayExpression > Literal[value=404]': (node) => {
+        context.report(node, "Use 204 instead of 404 status code to indicate no content");
+      },
+      'NewExpression[callee.name="NetworkRequestConfiguration"] ObjectExpression Property[key.name="errorCodes"] ArrayExpression > Literal[value=404]': (node) => {
+        context.report(node, "Use 204 instead of 404 status code to indicate no content");
+      },
+    };
+  },
+};


### PR DESCRIPTION
This PR creates a new eslint rule that ensures that 404 is not used as an expected response for network requests. I will create PRs to update the eslint plugin version for root-web, root-mobile and myles-mobile. I have tested all 3 projects locally pointing them to this branch, and they flag the error when 404 is used as an expected response.