### PR TITLE
Adds a linter rule for invalid test filenames

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -84,6 +84,7 @@ module.exports = {
     'root/preceded-by-await': ['error', { 'functionNames': ['pollForCondition', 'wait', 'waitForElement'] }],
     'root/prevent-unused-connect-functions': 'error',
     'root/sort-reducers-index': 'error',
+    'root/valid-test-filenames': ['error', { 'testSuffix': '-test.js' }],
     'semi-spacing': 'error',
     'semi': 'error',
     'sort-imports-es6-autofix/sort-imports-es6': [2, {

--- a/lib/rules/valid-test-filenames.js
+++ b/lib/rules/valid-test-filenames.js
@@ -11,23 +11,27 @@ module.exports = {
           testSuffix: {
             type: 'string',
           },
+          whitelist: {
+            default: [],
+            type: 'array',
+          },
         },
       },
     ],
   },
 
   create(context) {
-    let alreadyReported = false;
+    let reported = false;
 
     const error = (context) => (node) => {
-      const testSuffix = context.options[0].testSuffix;
+      const { testSuffix, whitelist } = context.options[0];
+      const filename = context.getFilename();
 
-      if (alreadyReported || context.getFilename().endsWith(testSuffix)) {
-        return;
-      }
+      if (reported) { return; }
+      if (whitelist.some((allowedFilename) => filename.endsWith(allowedFilename))) { return; }
+      if (filename.endsWith(testSuffix)) { return; }
 
-      alreadyReported = true;
-
+      reported = true;
       context.report({
         node,
         message: `Test filenames must end with ${testSuffix}`,

--- a/lib/rules/valid-test-filenames.js
+++ b/lib/rules/valid-test-filenames.js
@@ -1,0 +1,44 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Test filenames must be correct or they will not run on CI.',
+    },
+    fixable: false,
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          testSuffix: {
+            type: 'string',
+          },
+        },
+      },
+    ],
+  },
+
+  create(context) {
+    let alreadyReported = false;
+
+    const error = (context) => (node) => {
+      const testSuffix = context.options[0].testSuffix;
+
+      if (alreadyReported || context.getFilename().endsWith(testSuffix)) {
+        return;
+      }
+
+      alreadyReported = true;
+
+      context.report({
+        node,
+        message: `Test filenames must end with ${testSuffix}`,
+      });
+    };
+
+    return {
+      'CallExpression[callee.name="context"]': error(context),
+      'CallExpression[callee.name="describe"]': error(context),
+      'CallExpression[callee.name="it"]': error(context),
+      'CallExpression[callee.name="itSlowly"]': error(context),
+    };
+  },
+};

--- a/test/lib/rules/valid-test-filenames-test.js
+++ b/test/lib/rules/valid-test-filenames-test.js
@@ -1,0 +1,121 @@
+const rule = require('../../../lib/rules/valid-test-filenames');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('valid-test-filenames', rule, {
+  valid: [
+    {
+      code: 'function Component() { return null; }',
+      filename: 'src/components/some-component.js',
+      options: [{ testSuffix: '-test.js' }],
+    },
+    {
+      code: 'function itDoesAThing() { return true; }',
+      filename: 'src/models/some-model.js',
+      options: [{ testSuffix: '-test.js' }],
+    },
+    {
+      code: 'describe("Component", function() {});',
+      filename: 'test/components/some-component-test.js',
+      options: [{ testSuffix: '-test.js' }],
+    },
+    {
+      code: 'it("does a thing", function() {});',
+      filename: 'test/models/some-model-test.js',
+      options: [{ testSuffix: '-test.js' }],
+    },
+    {
+      code: 'itSlowly("does a thing", function() {});',
+      filename: 'test/models/some-model-test.js',
+      options: [{ testSuffix: '-test.js' }],
+    },
+    {
+      code: 'context("when doing a thing", function() {});',
+      filename: 'test/models/some-model-test.js',
+      options: [{ testSuffix: '-test.js' }],
+    },
+    {
+      code: 'describe("Component", function() {});',
+      filename: 'test/components/some-component-spec.js',
+      options: [{ testSuffix: '-spec.js' }],
+    },
+    {
+      code: 'it("does a thing", function() {});',
+      filename: 'test/models/some-model-spec.js',
+      options: [{ testSuffix: '-spec.js' }],
+    },
+    {
+      code: 'itSlowly("does a thing", function() {});',
+      filename: 'test/models/some-model-spec.js',
+      options: [{ testSuffix: '-spec.js' }],
+    },
+    {
+      code: 'context("when doing a thing", function() {});',
+      filename: 'test/models/some-model-spec.js',
+      options: [{ testSuffix: '-spec.js' }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'describe("Component", function() {});',
+      filename: 'test/components/some-component.js',
+      options: [{ testSuffix: '-test.js' }],
+      errors: [{ message: 'Test filenames must end with -test.js' }]
+    },
+    {
+      code: 'describe("Component", function() { context ("when foo", function() { it("bars", function() {}) }) });',
+      filename: 'test/components/some-component.js',
+      options: [{ testSuffix: '-test.js' }],
+      errors: [{ message: 'Test filenames must end with -test.js' }]
+    },
+    {
+      code: 'it("does a thing", function() {});',
+      filename: 'test/models/some-model.js',
+      options: [{ testSuffix: '-test.js' }],
+      errors: [{ message: 'Test filenames must end with -test.js' }]
+    },
+    {
+      code: 'itSlowly("does a thing", function() {});',
+      filename: 'test/models/some-model.js',
+      options: [{ testSuffix: '-test.js' }],
+      errors: [{ message: 'Test filenames must end with -test.js' }]
+    },
+    {
+      code: 'context("when doing a thing", function() {});',
+      filename: 'test/models/some-model.js',
+      options: [{ testSuffix: '-test.js' }],
+      errors: [{ message: 'Test filenames must end with -test.js' }]
+    },
+    {
+      code: 'describe("Component", function() {});',
+      filename: 'test/components/some-component.js',
+      options: [{ testSuffix: '-spec.js' }],
+      errors: [{ message: 'Test filenames must end with -spec.js' }]
+    },
+    {
+      code: 'describe("Component", function() { context ("when foo", function() { it("bars", function() {}) }) });',
+      filename: 'test/components/some-component.js',
+      options: [{ testSuffix: '-spec.js' }],
+      errors: [{ message: 'Test filenames must end with -spec.js' }]
+    },
+    {
+      code: 'it("does a thing", function() {});',
+      filename: 'test/models/some-model.js',
+      options: [{ testSuffix: '-spec.js' }],
+      errors: [{ message: 'Test filenames must end with -spec.js' }]
+    },
+    {
+      code: 'itSlowly("does a thing", function() {});',
+      filename: 'test/models/some-model.js',
+      options: [{ testSuffix: '-spec.js' }],
+      errors: [{ message: 'Test filenames must end with -spec.js' }]
+    },
+    {
+      code: 'context("when doing a thing", function() {});',
+      filename: 'test/models/some-model.js',
+      options: [{ testSuffix: '-spec.js' }],
+      errors: [{ message: 'Test filenames must end with -spec.js' }]
+    },
+  ],
+});

--- a/test/lib/rules/valid-test-filenames-test.js
+++ b/test/lib/rules/valid-test-filenames-test.js
@@ -55,67 +55,117 @@ ruleTester.run('valid-test-filenames', rule, {
       filename: 'test/models/some-model-spec.js',
       options: [{ testSuffix: '-spec.js' }],
     },
+    {
+      code: 'describe("Component", function() {});',
+      filename: 'test/components/some-component.js',
+      options: [{ testSuffix: '-test.js', whitelist: ['test/components/some-component.js'] }],
+    },
+    {
+      code: 'describe("Component", function() { context ("when foo", function() { it("bars", function() {}) }) });',
+      filename: 'test/components/some-component.js',
+      options: [{ testSuffix: '-test.js', whitelist: ['test/components/some-component.js'] }],
+    },
+    {
+      code: 'it("does a thing", function() {});',
+      filename: 'test/models/some-model.js',
+      options: [{ testSuffix: '-test.js', whitelist: ['test/models/some-model.js'] }],
+    },
+    {
+      code: 'itSlowly("does a thing", function() {});',
+      filename: 'test/models/some-model.js',
+      options: [{ testSuffix: '-test.js', whitelist: ['test/models/some-model.js'] }],
+    },
+    {
+      code: 'context("when doing a thing", function() {});',
+      filename: 'test/models/some-model.js',
+      options: [{ testSuffix: '-test.js', whitelist: ['test/models/some-model.js'] }],
+    },
+    {
+      code: 'describe("Component", function() {});',
+      filename: 'test/components/some-component.js',
+      options: [{ testSuffix: '-spec.js', whitelist: ['test/components/some-component.js'] }],
+    },
+    {
+      code: 'describe("Component", function() { context ("when foo", function() { it("bars", function() {}) }) });',
+      filename: 'test/components/some-component.js',
+      options: [{ testSuffix: '-spec.js', whitelist: ['test/components/some-component.js'] }],
+    },
+    {
+      code: 'it("does a thing", function() {});',
+      filename: 'test/models/some-model.js',
+      options: [{ testSuffix: '-spec.js', whitelist: ['test/models/some-model.js'] }],
+    },
+    {
+      code: 'itSlowly("does a thing", function() {});',
+      filename: 'test/models/some-model.js',
+      options: [{ testSuffix: '-spec.js', whitelist: ['test/models/some-model.js'] }],
+    },
+    {
+      code: 'context("when doing a thing", function() {});',
+      filename: 'test/models/some-model.js',
+      options: [{ testSuffix: '-spec.js', whitelist: ['test/models/some-model.js'] }],
+    },
   ],
   invalid: [
     {
       code: 'describe("Component", function() {});',
       filename: 'test/components/some-component.js',
       options: [{ testSuffix: '-test.js' }],
-      errors: [{ message: 'Test filenames must end with -test.js' }]
+      errors: [{ message: 'Test filenames must end with -test.js' }],
     },
     {
       code: 'describe("Component", function() { context ("when foo", function() { it("bars", function() {}) }) });',
       filename: 'test/components/some-component.js',
       options: [{ testSuffix: '-test.js' }],
-      errors: [{ message: 'Test filenames must end with -test.js' }]
+      errors: [{ message: 'Test filenames must end with -test.js' }],
     },
     {
       code: 'it("does a thing", function() {});',
       filename: 'test/models/some-model.js',
       options: [{ testSuffix: '-test.js' }],
-      errors: [{ message: 'Test filenames must end with -test.js' }]
+      errors: [{ message: 'Test filenames must end with -test.js' }],
     },
     {
       code: 'itSlowly("does a thing", function() {});',
       filename: 'test/models/some-model.js',
       options: [{ testSuffix: '-test.js' }],
-      errors: [{ message: 'Test filenames must end with -test.js' }]
+      errors: [{ message: 'Test filenames must end with -test.js' }],
     },
     {
       code: 'context("when doing a thing", function() {});',
       filename: 'test/models/some-model.js',
       options: [{ testSuffix: '-test.js' }],
-      errors: [{ message: 'Test filenames must end with -test.js' }]
+      errors: [{ message: 'Test filenames must end with -test.js' }],
     },
     {
       code: 'describe("Component", function() {});',
       filename: 'test/components/some-component.js',
       options: [{ testSuffix: '-spec.js' }],
-      errors: [{ message: 'Test filenames must end with -spec.js' }]
+      errors: [{ message: 'Test filenames must end with -spec.js' }],
     },
     {
       code: 'describe("Component", function() { context ("when foo", function() { it("bars", function() {}) }) });',
       filename: 'test/components/some-component.js',
       options: [{ testSuffix: '-spec.js' }],
-      errors: [{ message: 'Test filenames must end with -spec.js' }]
+      errors: [{ message: 'Test filenames must end with -spec.js' }],
     },
     {
       code: 'it("does a thing", function() {});',
       filename: 'test/models/some-model.js',
       options: [{ testSuffix: '-spec.js' }],
-      errors: [{ message: 'Test filenames must end with -spec.js' }]
+      errors: [{ message: 'Test filenames must end with -spec.js' }],
     },
     {
       code: 'itSlowly("does a thing", function() {});',
       filename: 'test/models/some-model.js',
       options: [{ testSuffix: '-spec.js' }],
-      errors: [{ message: 'Test filenames must end with -spec.js' }]
+      errors: [{ message: 'Test filenames must end with -spec.js' }],
     },
     {
       code: 'context("when doing a thing", function() {});',
       filename: 'test/models/some-model.js',
       options: [{ testSuffix: '-spec.js' }],
-      errors: [{ message: 'Test filenames must end with -spec.js' }]
+      errors: [{ message: 'Test filenames must end with -spec.js' }],
     },
   ],
 });


### PR DESCRIPTION
This will prevent us from being in a situation where we aren't running tests in CI.

I ran the tests locally, but it looks like we don't have CI on this. They passed on my machine.