### PR TITLE
Add linter rules to allow describeWithThrownErrors

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -103,5 +103,6 @@ module.exports = {
   'globals': {
     'ENV': false,
     'itSlowly': false,
+    'describeWithThrownErrors': false,
   }
 };

--- a/lib/rules/valid-test-filenames.js
+++ b/lib/rules/valid-test-filenames.js
@@ -41,6 +41,7 @@ module.exports = {
     return {
       'CallExpression[callee.name="context"]': error(context),
       'CallExpression[callee.name="describe"]': error(context),
+      'CallExpression[callee.name="describeWithThrownErrors"]': error(context),
       'CallExpression[callee.name="it"]': error(context),
       'CallExpression[callee.name="itSlowly"]': error(context),
     };

--- a/test/lib/rules/valid-test-filenames-test.js
+++ b/test/lib/rules/valid-test-filenames-test.js
@@ -120,6 +120,12 @@ ruleTester.run('valid-test-filenames', rule, {
       errors: [{ message: 'Test filenames must end with -test.js' }],
     },
     {
+      code: 'describeWithThrownErrors("Component", function() { context ("when foo", function() { it("bars", function() {}) }) });',
+      filename: 'test/models/some-model.js',
+      options: [{ testSuffix: '-test.js' }],
+      errors: [{ message: 'Test filenames must end with -test.js' }],
+    },
+    {
       code: 'it("does a thing", function() {});',
       filename: 'test/models/some-model.js',
       options: [{ testSuffix: '-test.js' }],


### PR DESCRIPTION
This PR updates the linter to allow for the new testing helper function merged in web with [this PR](https://github.com/Root-App/root-monorepo/pull/16750)