### PR TITLE
Adds rule to ensure abstract components only use react and abstract components

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -82,6 +82,7 @@ module.exports = {
     'root/integration-drivers-return-this-or-null': 'error',
     'root/integration-driver-import': 'error',
     'root/integration-test-format': 'error',
+    'root/only-use-abstract-and-react-native-components-in-abstract-components': 'error',
     'root/prefer-root-text': 'error',
     'root/preceded-by-await': ['error', { 'functionNames': ['pollForCondition', 'wait', 'waitForElement'] }],
     'root/prevent-async-test-without-it-slowly': 'error',

--- a/lib/rules/only-use-abstract-and-react-native-components-in-abstract-components.js
+++ b/lib/rules/only-use-abstract-and-react-native-components-in-abstract-components.js
@@ -1,0 +1,64 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Ensure only abstract and react-native components are used to build abstract components',
+    },
+    fixable: false,
+  },
+
+  create(context) {
+    const isAbstractComponent = context.getFilename().includes('/core-components/src/abstract');
+    const validElementSources = ['react-native'];
+    const validElementSourceDirectories = ['/core-components/src/abstract'];
+    const inValidElementSourceDirectories = ['/core-components/src/components'];
+
+    var validElements = [];
+
+    function isValidElementSource(path) {
+      return (
+        validElementSources.some(validSource => validSource === path) ||
+        validElementSourceDirectories.some(validSourceDirectory => path.includes(validSourceDirectory)) ||
+        path.startsWith('./')
+      );
+    }
+
+    function isInValidElementSource(path) {
+      return (inValidElementSourceDirectories.some(inValidSourceDirectory => path.includes(inValidSourceDirectory)));
+    }
+
+    function isValidElement(node) {
+      return validElements.includes(node.openingElement.name.name) ||
+        (node.openingElement.name.type === 'JSXMemberExpression' &&
+          node.openingElement.name.object.name === 'Animated' &&
+          validElements.includes(node.openingElement.name.property.name))
+    }
+
+    if (!isAbstractComponent) return {};
+
+    return {
+      ImportDeclaration(node) {
+        if (isInValidElementSource(node.source.value)) {
+          context.report({
+            node,
+            message: 'Abstract components should not rely on core components'
+          });
+        }
+
+        if (isValidElementSource(node.source.value)) {
+          validElements.push(...node.specifiers.map(specifier => specifier.imported.name));
+        }
+      },
+      VariableDeclaration(node) {
+        validElements.push(...node.declarations.map(declaration => declaration.id.name));
+      },
+      JSXElement(node) {
+        if (!isValidElement(node)) {
+          context.report({
+            node,
+            message: 'Render only abstract or react-native components inside of a abstract component'
+          });
+        }
+      }
+    };
+  }
+};

--- a/test/lib/rules/only-use-abstract-and-react-native-components-in-abstract-components-test.js
+++ b/test/lib/rules/only-use-abstract-and-react-native-components-in-abstract-components-test.js
@@ -1,0 +1,259 @@
+const rule = require('../../../lib/rules/only-use-abstract-and-react-native-components-in-abstract-components');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true
+    }
+  }
+});
+
+const message = 'Render only abstract or react-native components inside of a abstract component'
+const coreComponentImportMessage = 'Abstract components should not rely on core components'
+const filename = '/core-components/src/abstract/abstract-button.js'
+const nonAbstractFilename = 'src/component.js'
+
+ruleTester.run('only-use-abstract-and-react-native-components-in-abstract-components', rule, {
+  valid: [
+    {
+      code: `
+      import { AbstractCoreText } from '@root/core-components/src/abstract/abstract-core-text';
+      import { AbstractTouchableOpacity } from '@root/core-components/src/abstract/abstract-touchable-opacity';
+      import { View, ViewPropTypes } from 'react-native';
+
+      export const AbstractButton = forwardRef(({
+        someProps
+      }, ref,) => {
+
+        return (
+          <AbstractTouchableOpacity>
+            <View style={style}>
+              {leftIcon}
+              <AbstractCoreText
+                textProps={textProps}
+              >
+                {title}
+              </AbstractCoreText>
+            </View>
+            {leftAligned && rightIcon}
+          </AbstractTouchableOpacity>
+        );
+      });`,
+      filename,
+    },
+    {
+      code: `
+      import { AbstractCoreText } from '@root/core-components/src/abstract/abstract-core-text';
+      import { AbstractTouchableOpacity } from './abstract-touchable-opacity';
+      import { View, ViewPropTypes } from 'react-native';
+
+      export const AbstractButton = forwardRef(({
+        someProps
+      }, ref,) => {
+
+        return (
+          <AbstractTouchableOpacity>
+            <View style={style}>
+              {leftIcon}
+              <AbstractCoreText
+                textProps={textProps}
+              >
+                {title}
+              </AbstractCoreText>
+            </View>
+            {leftAligned && rightIcon}
+          </AbstractTouchableOpacity>
+        );
+      });`,
+      filename,
+    },
+    {
+      code: `
+      import { AbstractCoreText } from '@root/core-components/src/abstract/abstract-core-text';
+      import { AbstractTouchableOpacity } from '@root/core-components/src/abstract/abstract-touchable-opacity';
+      import { View, ViewPropTypes } from 'react-native';
+
+      export const AbstractButton = forwardRef(({
+        someProps
+      }, ref,) => {
+
+        return (
+          <AbstractTouchableOpacity>
+            <View style={style}>
+              {leftIcon}
+              <Animated.AbstractCoreText
+                textProps={textProps}
+              >
+                {title}
+              </Animated.AbstractCoreText>
+            </View>
+            {leftAligned && rightIcon}
+          </AbstractTouchableOpacity>
+        );
+      });`,
+      filename,
+    },
+    {
+      code: `
+      import { AbstractCoreText } from '@root/core-components/src/abstract/abstract-core-text';
+      import { AbstractTouchableOpacity } from '@root/core-components/src/abstract/abstract-touchable-opacity';
+      import { View, ViewPropTypes } from 'react-native';
+
+      export const AbstractButton = forwardRef(({
+        someProps
+      }, ref,) => {
+
+        const DynamicComponent = expression ? SomeComponent : SomeOtherComponent;
+
+        return (
+          <DynamicComponent>
+            <AbstractTouchableOpacity>
+              <View style={style}>
+                {leftIcon}
+                <AbstractCoreText
+                  textProps={textProps}
+                >
+                {title}
+                </AbstractCoreText>
+              </View>
+              {leftAligned && rightIcon}
+            </AbstractTouchableOpacity>
+          </DynamicComponent>
+        );
+      });`,
+      filename,
+      errors: [{ message }],
+    },
+    {
+      code: `
+      import { AbstractCoreText } from '@root/core-components/src/abstract/abstract-core-text';
+      import { AbstractTouchableOpacity } from '@root/core-components/src/abstract/abstract-touchable-opacity';
+      import { View, ViewPropTypes } from 'react-native';
+      import { CoreText } from '@root/core-components/src/components/core-text';
+
+      export const AbstractButton = forwardRef(({
+        someProps
+      }, ref,) => {
+
+        return (
+          <AbstractTouchableOpacity>
+            <View style={style}>
+              {leftIcon}
+              <AbstractCoreText
+                textProps={textProps}
+              >
+              {title}
+              <CoreText>
+              {subject}
+              </CoreText>
+              </AbstractCoreText>
+            </View>
+            {leftAligned && rightIcon}
+          </AbstractTouchableOpacity>
+        );
+      });`,
+      filename: nonAbstractFilename,
+      errors: [{ message }],
+    },
+  ],
+  invalid: [
+    {
+      code: `
+      import { AbstractCoreText } from '@root/core-components/src/abstract/abstract-core-text';
+      import { AbstractTouchableOpacity } from '@root/core-components/src/abstract/abstract-touchable-opacity';
+      import { View, ViewPropTypes } from 'react-native';
+      import { CoreText } from 'core-text';
+
+      export const AbstractButton = forwardRef(({
+        someProps
+      }, ref,) => {
+
+        return (
+          <AbstractTouchableOpacity>
+            <View style={style}>
+              {leftIcon}
+              <AbstractCoreText
+                textProps={textProps}
+              >
+              {title}
+              <CoreText>
+              {subject}
+              </CoreText>
+              </AbstractCoreText>
+            </View>
+            {leftAligned && rightIcon}
+          </AbstractTouchableOpacity>
+        );
+      });`,
+      filename,
+      errors: [{ message }],
+    },
+    {
+      code: `
+      import { AbstractCoreText } from '@root/core-components/src/abstract/abstract-core-text';
+      import { AbstractTouchableOpacity } from '@root/core-components/src/abstract/abstract-touchable-opacity';
+      import { View, ViewPropTypes } from 'react-native';
+      import { CoreText } from 'core-text';
+
+      export const AbstractButton = forwardRef(({
+        someProps
+      }, ref,) => {
+
+        return (
+          <AbstractTouchableOpacity>
+            <View style={style}>
+              {leftIcon}
+              <AbstractCoreText
+                textProps={textProps}
+              >
+              {title}
+              <Animated.CoreText>
+              {subject}
+              </Animated.CoreText>
+              </AbstractCoreText>
+            </View>
+            {leftAligned && rightIcon}
+          </AbstractTouchableOpacity>
+        );
+      });`,
+      filename,
+      errors: [{ message }],
+    },
+    {
+      code: `
+      import { AbstractCoreText } from '@root/core-components/src/abstract/abstract-core-text';
+      import { AbstractTouchableOpacity } from '@root/core-components/src/abstract/abstract-touchable-opacity';
+      import { View, ViewPropTypes } from 'react-native';
+      import { CoreText } from '@root/core-components/src/components/core-text';
+
+      export const AbstractButton = forwardRef(({
+        someProps
+      }, ref,) => {
+
+        const DynamicComponent = CoreText;
+
+        return (
+          <AbstractTouchableOpacity>
+            <View style={style}>
+              {leftIcon}
+              <AbstractCoreText
+                textProps={textProps}
+              >
+              {title}
+              <DynamicComponent>
+              {subject}
+              </DynamicComponent>
+              </AbstractCoreText>
+            </View>
+            {leftAligned && rightIcon}
+          </AbstractTouchableOpacity>
+        );
+      });`,
+      filename,
+      errors: [{ coreComponentImportMessage }],
+    },
+  ],
+});


### PR DESCRIPTION
- Adds rule to ensure abstract components only use react and abstract components

Because you can dynamically set a component at runtime, this is more of a shallow search and won't catch instances like the following:

```
const DynamicComponent = expression ? SomeComponent : SomeOtherComponent;
```

```
const DynamicComponent = returnsSomeComponent();
```