### PR TITLE
Adds rule to enforce importing StyleSheet from core-components instead of react-native

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -83,6 +83,7 @@ module.exports = {
     'root/integration-driver-import': 'error',
     'root/integration-test-format': 'error',
     'root/only-use-abstract-and-react-native-components-in-abstract-components': 'error',
+    'root/prefer-core-components-stylesheet': 'error',
     'root/prefer-root-text': 'error',
     'root/preceded-by-await': ['error', { 'functionNames': ['pollForCondition', 'wait', 'waitForElement'] }],
     'root/prevent-async-test-without-it-slowly': 'error',

--- a/lib/rules/prefer-core-components-stylesheet.js
+++ b/lib/rules/prefer-core-components-stylesheet.js
@@ -1,0 +1,42 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Use StyleSheet from core-components instead of react-native',
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    const sourceCode = context.getSourceCode();
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value != 'react-native') return {}
+        const styleSheetImport = node.specifiers.find((specifier) => (specifier.imported !== undefined && specifier.imported.name === 'StyleSheet'));
+        if (!styleSheetImport) return {}
+
+        if (sourceCode.getText(node).match(/^import\s\{\sStyleSheet\s\}\sfrom\s'react-native';$/)) {
+          context.report({
+            node,
+            message: 'Import StyleSheet from core-components instead of react-native',
+            fix: (fixer) => {
+              return [
+                fixer.replaceText(node, sourceCode.getText(node).replace(/^import\s\{\sStyleSheet\s\}\sfrom\s'react-native';$/, "import { StyleSheet } from '@root/core-components/src/utils/stylesheet';")),
+              ];
+            },
+          });
+        } else {
+          context.report({
+            node,
+            message: 'Import StyleSheet from core-components instead of react-native',
+            fix: (fixer) => {
+              return [
+                fixer.replaceText(node, sourceCode.getText(node).replace(/(,\s+StyleSheet)|(?<=\{\s+)(StyleSheet,\s+)/, '')),
+                fixer.insertTextAfter(node, "\nimport { StyleSheet } from '@root/core-components/src/utils/stylesheet';"),
+              ];
+            },
+          });
+        }
+
+      }
+    };
+  }
+};

--- a/test/lib/rules/prefer-core-components-stylesheet-test.js
+++ b/test/lib/rules/prefer-core-components-stylesheet-test.js
@@ -1,0 +1,113 @@
+const rule = require('../../../lib/rules/prefer-core-components-stylesheet');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true
+    }
+  }
+});
+
+ruleTester.run('prefer-core-components-stylesheet', rule, {
+  valid: [
+    {
+      code: `import { StyleSheet } from '@root/core-components/src/utils/stylesheet';`,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+import { StyleSheet } from 'react-native';`,
+      errors: [{ message: "Import StyleSheet from core-components instead of react-native" }],
+      output: `
+import { StyleSheet } from '@root/core-components/src/utils/stylesheet';`
+    },
+    {
+      code: `
+import { StyleSheet, View } from 'react-native';`,
+      errors: [{ message: "Import StyleSheet from core-components instead of react-native" }],
+      output: `
+import { View } from 'react-native';
+import { StyleSheet } from '@root/core-components/src/utils/stylesheet';`
+    },
+    {
+      code: `
+import { ListView, StyleSheet } from 'react-native';`,
+      errors: [{ message: "Import StyleSheet from core-components instead of react-native" }],
+      output: `
+import { ListView } from 'react-native';
+import { StyleSheet } from '@root/core-components/src/utils/stylesheet';`
+    },
+    {
+      code: `
+import { ListView, StyleSheet, View } from 'react-native';`,
+      errors: [{ message: "Import StyleSheet from core-components instead of react-native" }],
+      output: `
+import { ListView, View } from 'react-native';
+import { StyleSheet } from '@root/core-components/src/utils/stylesheet';`
+    },
+    {
+      code: `
+import {
+  StyleSheet,
+  ListView,
+  View
+} from 'react-native';`,
+      errors: [{ message: "Import StyleSheet from core-components instead of react-native" }],
+      output: `
+import {
+  ListView,
+  View
+} from 'react-native';
+import { StyleSheet } from '@root/core-components/src/utils/stylesheet';`
+    },
+    {
+      code: `
+import {
+  ListView,
+  StyleSheet,
+  View
+} from 'react-native';`,
+      errors: [{ message: "Import StyleSheet from core-components instead of react-native" }],
+      output: `
+import {
+  ListView,
+  View
+} from 'react-native';
+import { StyleSheet } from '@root/core-components/src/utils/stylesheet';`
+    },
+    {
+      code: `
+import {
+  ListView,
+  View,
+  StyleSheet
+} from 'react-native';`,
+      errors: [{ message: "Import StyleSheet from core-components instead of react-native" }],
+      output: `
+import {
+  ListView,
+  View
+} from 'react-native';
+import { StyleSheet } from '@root/core-components/src/utils/stylesheet';`
+    },
+    {
+      code: `
+import {
+  ListView,
+  View,
+  StyleSheet,
+} from 'react-native';`,
+      errors: [{ message: "Import StyleSheet from core-components instead of react-native" }],
+      output: `
+import {
+  ListView,
+  View,
+} from 'react-native';
+import { StyleSheet } from '@root/core-components/src/utils/stylesheet';`
+    },
+  ],
+});


### PR DESCRIPTION
- Adds rule to enforce importing StyleSheet from core-components instead of react-native with auto fix support

![linter-stylesheet-autofix-1](https://user-images.githubusercontent.com/410463/75078770-918da300-54d4-11ea-80f0-f6d36e811fb5.gif)

