### PR TITLE
Add enforce-type-styles rule

### DIFF
--- a/lib/rules/enforce-type-styles.js
+++ b/lib/rules/enforce-type-styles.js
@@ -1,0 +1,64 @@
+module.exports = {
+  meta: {
+    type: 'suggestion',
+
+    docs: {
+      description: 'Make sure only Theme is setting typography styles in stylesheets',
+      category: 'Design Style',
+    },
+    fixable: false,
+
+    schema: [
+      {
+        "type": "object",
+        "properties": {
+          "blacklist": {
+            "type": "array"
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  create(context) {
+    let optsBlacklist;
+    const [opts] = context.options;
+    if(opts && opts.blacklist){
+      optsBlacklist = opts.blacklist;
+    }
+    const blacklist = optsBlacklist || [
+      'fontSize',
+      'fontWeight',
+      'lineHeight',
+    ];
+
+    const hasInvalidStyleProps = (obj) => {
+      return obj.properties.some(prop =>
+        prop && prop.value && (
+          (prop.value.type === 'Literal' && blacklist.includes(prop.key.name))
+          || (prop.value.type === 'ObjectExpression' && hasInvalidStyleProps(prop.value))
+        )
+      )
+    };
+
+    return {
+      CallExpression(node) {
+        const {object, property} = node.callee;
+        const filename = context.getFilename();
+
+        if(object.name !== 'StyleSheet'
+          || property.name !== 'create'
+          || filename.search(/(brand|joinroot\.com|joinroot-cms)\/(.*)?theme/) !== -1) return;
+
+        const [stylesheet] = node.arguments;
+
+        if(hasInvalidStyleProps(stylesheet)){
+          context.report({
+            node,
+            message: `Only an imported Theme can set ${blacklist.join(', ')} in StyleSheet.create()`
+          })
+        }
+      }
+    };
+  }
+}

--- a/test/lib/rules/enforce-type-styles-test.js
+++ b/test/lib/rules/enforce-type-styles-test.js
@@ -1,0 +1,130 @@
+const rule = require('../../../lib/rules/enforce-type-styles');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true
+    }
+  }
+});
+
+const blacklist = [
+  'fontSize',
+  'fontWeight',
+  'lineHeight',
+];
+
+const message = `Only an imported Theme can set ${blacklist.join(', ')} in StyleSheet.create()`;
+
+ruleTester.run('enforce-type-styles', rule, {
+  valid: [
+    {
+      code: `
+      const styles = StyleSheet.create({
+        heading: {
+          ...Theme.heading1(),
+          color: Colors.nearBlack(),
+        },
+        subtext: {
+          ...Theme.paragraph1(),
+        }
+      });
+      `,
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
+        heading: {
+          fontSize: 24,
+          fontWeight: 400,
+          lineHeight: 1.1,
+          color: Colors.nearBlack(),
+        }
+      });
+      `,
+      filename: 'brand/src/utils/theme.js'
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
+        heading: {
+          fontSize: 24,
+          fontWeight: 400,
+          lineHeight: 1.1,
+          color: Colors.nearBlack(),
+        }
+      });
+      `,
+      filename: 'joinroot.com/src/utils/theme.js'
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
+        heading: {
+          fontSize: 24,
+          fontWeight: 400,
+          lineHeight: 1.1,
+          color: Colors.nearBlack(),
+        }
+      });
+      `,
+      filename: 'joinroot-cms/src/utils/theme.js'
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
+        heading: {
+          fontWeight: 400,
+          lineHeight: 1.1,
+          color: Colors.nearBlack(),
+        }
+      });
+      `,
+      options: [
+        {
+          blacklist: [
+            'fontSize',
+          ]
+        }
+      ]
+    },
+  ],
+  invalid: [
+    {
+      code: `
+      const styles = StyleSheet.create({
+        heading: {
+          fontSize: 24,
+          fontWeight: 400,
+          lineHeight: 1.1,
+          color: Colors.nearBlack(),
+        }
+      });
+      `,
+      errors: [{ message }],
+    },
+    {
+      code: `
+      const styles = StyleSheet.create({
+        heading: {
+          fontWeight: 400,
+          color: Colors.nearBlack(),
+        }
+      });
+      `,
+      options: [
+        {
+          blacklist: [
+            'fontWeight',
+          ]
+        }
+      ],
+      errors: [{
+        message: 'Only an imported Theme can set fontWeight in StyleSheet.create()'
+      }],
+    }
+  ]
+})


### PR DESCRIPTION
This PR adds a new lint rule to enforce type styles so they are only set in a theme file in one of the following modules:
- `brand`
- `joinroot.com`
- `joinroot-cms`

Basically it works by checking to see if any of the properties inside a `StyleSheet.create({})` parameter are setting any of the following blacklisted items:
- `fontSize`
- `fontWeight`
- `lineHeight`

You can change this blacklist by supplying an options object to the rule in the eslint config:
```js
// This config would only check for fontSize and fontWeight
module.exports = {
  'rules': [
    'enforce-type-styles': [{
      'blacklist': ['fontSize', 'fontWeight']
    }]
  ]
}
```

_By default this rule is labeled as a suggestion so will only output when running `yarn lint` but will not fail at build time_