### PR TITLE
Adds linter rule to prevent overriding breakpoint values.

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -87,6 +87,7 @@ module.exports = {
     'root/prefer-root-text': 'error',
     'root/preceded-by-await': ['error', { 'functionNames': ['pollForCondition', 'wait', 'waitForElement'] }],
     'root/prevent-async-test-without-it-slowly': 'error',
+    'root/prevent-overriding-breakpoint-values-outside-of-tests': 'error',
     'root/prevent-unused-connect-functions': 'error',
     'root/sort-reducers-index': 'error',
     'root/valid-test-filenames': ['error', { 'testSuffix': '-test.js' }],

--- a/lib/rules/prevent-overriding-breakpoint-values-outside-of-tests.js
+++ b/lib/rules/prevent-overriding-breakpoint-values-outside-of-tests.js
@@ -1,0 +1,37 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Prevent overriding BreakpointValues outside of tests',
+    },
+  },
+  create(context) {
+    const filename = context.getFilename();
+    if (filename.includes("/test/")) return {};
+
+    var importedBreakpoints = []
+
+    return {
+      ImportDeclaration(node) {
+        if (!node.source.value.includes('core-components/src/utils/breakpoints')) return {}
+
+        const breakpointSpecifiers = node.specifiers.find((specifier) => (specifier.local && specifier.local.name === 'BreakpointValues'))
+        if (breakpointSpecifiers) {
+          importedBreakpoints.push(breakpointSpecifiers.imported.name)
+        }
+      },
+      VariableDeclarator(node) {
+        if (node.init && importedBreakpoints.includes(node.init.name)) {
+          importedBreakpoints.push(node.id.name);
+        }
+      },
+      AssignmentExpression(node) {
+        if (!node.left.object || !importedBreakpoints.includes(node.left.object.name)) return {};
+
+        context.report({
+          node,
+          message: 'Do not manipulate BreakpointValues outside of tests',
+        });
+      }
+    };
+  }
+};

--- a/test/lib/rules/prevent-overriding-breakpoint-values-outside-of-tests-test.js
+++ b/test/lib/rules/prevent-overriding-breakpoint-values-outside-of-tests-test.js
@@ -1,0 +1,82 @@
+const rule = require('../../../lib/rules/prevent-overriding-breakpoint-values-outside-of-tests');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true
+    }
+  }
+});
+
+const message = 'Do not manipulate BreakpointValues outside of tests';
+const filename = '/anywhere-not-in-a-test-directory.js'
+const testFilename = '/test/somewhere-in-a-test-directory.js'
+
+ruleTester.run('prevent-overriding-breakpoint-values-outside-of-tests', rule, {
+  valid: [
+    {
+      code: `
+import { BreakpointValues } from '@root/core-components/src/utils/breakpoints';
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: BreakpointValues.isSmall ? 10 : 20,
+  },
+});
+`,
+      filename,
+    },
+    {
+      code: `
+import { BreakpointValues } from '@root/core-components/src/utils/another-location';
+BreakpointValues.isSmall = false;
+`,
+      filename,
+    },
+    {
+      code: `
+import { BreakpointValues } from '@root/core-components/src/utils/breakpoints';
+BreakpointValues.isSmall = false;
+`,
+      filename: testFilename,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+import { BreakpointValues } from '@root/core-components/src/utils/breakpoints';
+BreakpointValues.isSmall = false;
+`,
+      errors: [{ message }],
+      filename,
+    },
+    {
+      code: `
+import { BreakpointValues } from '@root/core-components/src/utils/breakpoints';
+BreakpointValues.isAnything = false;
+`,
+      errors: [{ message }],
+      filename,
+    },
+    {
+      code: `
+import { obfuscatedValue as BreakpointValues } from '@root/core-components/src/utils/breakpoints';
+obfuscatedValue.isSmall = false;
+`,
+      errors: [{ message }],
+      filename,
+    },
+    {
+      code: `
+import { BreakpointValues } from '@root/core-components/src/utils/breakpoints';
+const obfuscatedValue = BreakpointValues;
+obfuscatedValue.isSmall = false;
+`,
+      errors: [{ message }],
+      filename,
+    },
+  ],
+});


### PR DESCRIPTION
- Prevents overriding breakpoint values outside of tests.