### PR TITLE
Fixes abstract component linter rule for the Animated case

### DIFF
--- a/lib/rules/only-use-abstract-and-react-native-components-in-abstract-components.js
+++ b/lib/rules/only-use-abstract-and-react-native-components-in-abstract-components.js
@@ -30,7 +30,7 @@ module.exports = {
       return validElements.includes(node.openingElement.name.name) ||
         (node.openingElement.name.type === 'JSXMemberExpression' &&
           node.openingElement.name.object.name === 'Animated' &&
-          validElements.includes(node.openingElement.name.property.name))
+          validElements.includes(node.openingElement.name.object.name))
     }
 
     if (!isAbstractComponent) return {};

--- a/test/lib/rules/only-use-abstract-and-react-native-components-in-abstract-components-test.js
+++ b/test/lib/rules/only-use-abstract-and-react-native-components-in-abstract-components-test.js
@@ -74,7 +74,7 @@ ruleTester.run('only-use-abstract-and-react-native-components-in-abstract-compon
       code: `
       import { AbstractCoreText } from '@root/core-components/src/abstract/abstract-core-text';
       import { AbstractTouchableOpacity } from '@root/core-components/src/abstract/abstract-touchable-opacity';
-      import { View, ViewPropTypes } from 'react-native';
+      import { Animated, View, ViewPropTypes } from 'react-native';
 
       export const AbstractButton = forwardRef(({
         someProps
@@ -90,6 +90,29 @@ ruleTester.run('only-use-abstract-and-react-native-components-in-abstract-compon
                 {title}
               </Animated.AbstractCoreText>
             </View>
+            {leftAligned && rightIcon}
+          </AbstractTouchableOpacity>
+        );
+      });`,
+      filename,
+    },
+    {
+      code: `
+      import { AbstractCoreText } from '@root/core-components/src/abstract/abstract-core-text';
+      import { AbstractTouchableOpacity } from '@root/core-components/src/abstract/abstract-touchable-opacity';
+      import { Animated, ViewPropTypes } from 'react-native';
+
+      export const AbstractButton = forwardRef(({
+        someProps
+      }, ref,) => {
+
+        return (
+          <AbstractTouchableOpacity>
+            <Animated.View
+              textProps={textProps}
+            >
+              {title}
+            </Animated.View>
             {leftAligned && rightIcon}
           </AbstractTouchableOpacity>
         );
@@ -196,37 +219,6 @@ ruleTester.run('only-use-abstract-and-react-native-components-in-abstract-compon
       import { AbstractCoreText } from '@root/core-components/src/abstract/abstract-core-text';
       import { AbstractTouchableOpacity } from '@root/core-components/src/abstract/abstract-touchable-opacity';
       import { View, ViewPropTypes } from 'react-native';
-      import { CoreText } from 'core-text';
-
-      export const AbstractButton = forwardRef(({
-        someProps
-      }, ref,) => {
-
-        return (
-          <AbstractTouchableOpacity>
-            <View style={style}>
-              {leftIcon}
-              <AbstractCoreText
-                textProps={textProps}
-              >
-              {title}
-              <Animated.CoreText>
-              {subject}
-              </Animated.CoreText>
-              </AbstractCoreText>
-            </View>
-            {leftAligned && rightIcon}
-          </AbstractTouchableOpacity>
-        );
-      });`,
-      filename,
-      errors: [{ message }],
-    },
-    {
-      code: `
-      import { AbstractCoreText } from '@root/core-components/src/abstract/abstract-core-text';
-      import { AbstractTouchableOpacity } from '@root/core-components/src/abstract/abstract-touchable-opacity';
-      import { View, ViewPropTypes } from 'react-native';
       import { CoreText } from '@root/core-components/src/components/core-text';
 
       export const AbstractButton = forwardRef(({
@@ -248,6 +240,31 @@ ruleTester.run('only-use-abstract-and-react-native-components-in-abstract-compon
               </DynamicComponent>
               </AbstractCoreText>
             </View>
+            {leftAligned && rightIcon}
+          </AbstractTouchableOpacity>
+        );
+      });`,
+      filename,
+      errors: [{ coreComponentImportMessage }],
+    },
+    {
+      code: `
+      import { AbstractCoreText } from '@root/core-components/src/abstract/abstract-core-text';
+      import { AbstractTouchableOpacity } from '@root/core-components/src/abstract/abstract-touchable-opacity';
+      import { Animated } from 'somewhere-not-react-native';
+      import { ViewPropTypes } from 'react-native';
+
+      export const AbstractButton = forwardRef(({
+        someProps
+      }, ref,) => {
+
+        return (
+          <AbstractTouchableOpacity>
+            <Animated.View
+              textProps={textProps}
+            >
+              {title}
+            </Animated.View>
             {leftAligned && rightIcon}
           </AbstractTouchableOpacity>
         );


### PR DESCRIPTION
The original rule was a little over constrained causing issues with Animated, since you don't have to import the `react-native` component you are animating. Ex: https://github.com/Root-App/root-mobile/pull/6229/files#diff-53879583c40d6b770ebe77ad7776689aR28

Since Animated isn't used that often, and is not currently used with a core component or shared component, I've opted to be more permissive with the use of Animated.