### PR TITLE
Adds eslint rules for async before hooks

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -88,6 +88,8 @@ module.exports = {
     'root/prefer-root-text': 'error',
     'root/preceded-by-await': ['error', { 'functionNames': ['pollForCondition', 'wait', 'waitForElement'] }],
     'root/prevent-async-test-without-it-slowly': 'error',
+    'root/prevent-async-before-all-without-before-all-slowly': 'error',
+    'root/prevent-async-before-each-without-before-each-slowly': 'error',
     'root/prevent-non-smart-quotes-in-english-text': 'error',
     'root/prevent-overriding-breakpoint-values-outside-of-tests': 'error',
     'root/prevent-unused-connect-functions': 'error',
@@ -118,6 +120,8 @@ module.exports = {
   'globals': {
     'ENV': false,
     'itSlowly': false,
+    'beforeEachSlowly': false,
+    'beforeAllSlowly': false,
     'describeWithThrownErrors': false,
   }
 };

--- a/lib/rules/prevent-async-before-all-without-before-all-slowly.js
+++ b/lib/rules/prevent-async-before-all-without-before-all-slowly.js
@@ -1,0 +1,26 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Use beforeAllSlowly when testing asynchronous code',
+    },
+    fixable: 'code',
+  },
+
+  create(context) {
+    return {
+      'CallExpression[callee.name=beforeAll][arguments]'(node) {
+          if (node && node.arguments && node.arguments.length === 1) {
+            const testFunction = node.arguments[0];
+
+          if (testFunction.async) {
+            context.report({
+              node,
+              message: "Use beforeAllSlowly when testing asynchronous code",
+              fix: (fixer) => fixer.replaceText(node.callee, 'beforeAllSlowly'),
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/lib/rules/prevent-async-before-each-without-before-each-slowly.js
+++ b/lib/rules/prevent-async-before-each-without-before-each-slowly.js
@@ -1,0 +1,26 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Use beforeEachSlowly when testing asynchronous code',
+    },
+    fixable: 'code',
+  },
+
+  create(context) {
+    return {
+      'CallExpression[callee.name=beforeEach][arguments]'(node) {
+          if (node && node.arguments && node.arguments.length === 1) {
+            const testFunction = node.arguments[0];
+
+          if (testFunction.async) {
+            context.report({
+              node,
+              message: "Use beforeEachSlowly when testing asynchronous code",
+              fix: (fixer) => fixer.replaceText(node.callee, 'beforeEachSlowly'),
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/test/lib/rules/prevent-async-before-all-without-before-all-slowly-test.js
+++ b/test/lib/rules/prevent-async-before-all-without-before-all-slowly-test.js
@@ -1,0 +1,41 @@
+const rule = require('../../../lib/rules/prevent-async-before-all-without-before-all-slowly');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018, sourceType: 'module' } });
+
+ruleTester.run('prevent-async-before-all-without-before-all-slowly', rule, {
+  valid: [
+    {
+      code: `beforeAllSlowly(async () => {
+               await wait(() => {});
+             });`,
+      filename: 'tests/some-test.js',
+      options: [{ functionNames: ['wait'] }],
+    },
+    {
+      code: `beforeAll(() => {
+               wait(() => {});
+             });`,
+      filename: 'tests/some-test.js',
+      options: [{ functionNames: ['wait'] }],
+    },
+    {
+      code: `beforeAll(async () => {
+               await wait(() => {});
+             }, 100000);`,
+      filename: 'tests/some-test.js',
+      options: [{ functionNames: ['wait'] }],
+    }
+  ],
+
+  invalid: [
+    {
+      code: `beforeAll(async () => {
+               await wait(() => {});
+             });`,
+      filename: 'tests/some-test.js',
+      errors: [{ message: 'Use beforeAllSlowly when testing asynchronous code' }],
+      options: [{ functionNames: ['wait'] }],
+    },
+  ],
+});

--- a/test/lib/rules/prevent-async-before-each-without-before-each-slowly-test.js
+++ b/test/lib/rules/prevent-async-before-each-without-before-each-slowly-test.js
@@ -1,0 +1,41 @@
+const rule = require('../../../lib/rules/prevent-async-before-each-without-before-each-slowly');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018, sourceType: 'module' } });
+
+ruleTester.run('prevent-async-before-each-without-before-each-slowly', rule, {
+  valid: [
+    {
+      code: `beforeEachSlowly(async () => {
+               await wait(() => {});
+             });`,
+      filename: 'tests/some-test.js',
+      options: [{ functionNames: ['wait'] }],
+    },
+    {
+      code: `beforeEach(() => {
+               wait(() => {});
+             });`,
+      filename: 'tests/some-test.js',
+      options: [{ functionNames: ['wait'] }],
+    },
+    {
+      code: `beforeEach(async () => {
+               await wait(() => {});
+             }, 100000);`,
+      filename: 'tests/some-test.js',
+      options: [{ functionNames: ['wait'] }],
+    }
+  ],
+
+  invalid: [
+    {
+      code: `beforeEach(async () => {
+               await wait(() => {});
+             });`,
+      filename: 'tests/some-test.js',
+      errors: [{ message: 'Use beforeEachSlowly when testing asynchronous code' }],
+      options: [{ functionNames: ['wait'] }],
+    },
+  ],
+});


### PR DESCRIPTION
This PR adds two new eslint rules that change `beforeEach` and `beforeAll` to `beforeEachSlowly` and `beforeAllSlowly` if the test is `async` and does not contain a timeout.

Here is the corresponding monorepo [PR](https://github.com/Root-App/root-monorepo/pull/26848) that adds the `beforeEachSlowly` and `beforeAllSlowly` helpers and updates all async uses of `beforeEach` and `beforeAll` to the new slowly helpers.

We followed the pattern in this [PR](https://github.com/Root-App/root-eslint-plugin/pull/21) that adds the `it` -> `itSlowly` rule. 

[Clubhouse Card](https://app.clubhouse.io/joinroot/story/68761/create-eslint-rule-that-prevents-making-before-each-async)